### PR TITLE
断线重连重新添加心跳

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -396,6 +396,9 @@ class Client
             $headers['ack'] = $item['ack'];
             $this->subscribe($destination, $callback, $headers);
         }
+        if ($this->_options['heart_beat'][0]) {
+            $this->setPingTimer($this->_options['heart_beat'][0]/1000);
+        }
     }
 
     /**


### PR DESCRIPTION
处理 https://github.com/walkor/stomp/issues/3 
在 `Workerman\Stomp\Client.php`  的  `onStompReconnect` 方法最后添加代码：
```
if ($this->_options['heart_beat'][0]) {
    $this->setPingTimer($this->_options['heart_beat'][0]/1000);
}
```
